### PR TITLE
Support AssumeRole via .aws/config

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -2,3 +2,4 @@
 --require spec_helper
 --require rspec/instafail
 --format RSpec::Instafail
+--format progress

--- a/.rspec
+++ b/.rspec
@@ -2,4 +2,4 @@
 --require spec_helper
 --require rspec/instafail
 --format RSpec::Instafail
---format progress
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: ruby
 rvm:
 - 2.0.0
 script:
-- bundle install
 - bundle exec rake
 env:
   global:

--- a/bin/piculet
+++ b/bin/piculet
@@ -67,15 +67,15 @@ ARGV.options do |opt|
       if profile_name
         credentials_opts[:profile_name] = profile_name
         role_arn = AWSConfig[profile_name][:role_arn]
-      else
-        role_arn = AWSConfig.default.role_arn
-        profile_name = 'default'
       end
       if role_arn
-        AWSConfig[profile_name].config_hash
         session_name = "piculet-session-#{Time.now.to_i}"
         sts = AWS::STS.new(AWSConfig[profile_name].config_hash)
-        provider = AWS::Core::CredentialProviders::AssumeRoleProvider.new(sts: sts, role_arn: role_arn, role_session_name: session_name)
+        provider = AWS::Core::CredentialProviders::AssumeRoleProvider.new(
+          sts: sts,
+          role_arn: role_arn,
+          role_session_name: session_name
+        )
       else
         provider = AWS::Core::CredentialProviders::SharedCredentialFileProvider.new(credentials_opts)
       end

--- a/bin/piculet
+++ b/bin/piculet
@@ -60,9 +60,25 @@ ARGV.options do |opt|
       }
     elsif profile_name or credentials_path
       credentials_opts = {}
-      credentials_opts[:profile_name] = profile_name if profile_name
-      credentials_opts[:path] = credentials_path if credentials_path
-      provider = AWS::Core::CredentialProviders::SharedCredentialFileProvider.new(credentials_opts)
+      if credentials_path
+        credentials_opts[:path] = credentials_path
+        AWSConfig.credentials_file = credentials_path
+      end
+      if profile_name
+        credentials_opts[:profile_name] = profile_name
+        role_arn = AWSConfig[profile_name][:role_arn]
+      else
+        role_arn = AWSConfig.default.role_arn
+        profile_name = 'default'
+      end
+      if role_arn
+        AWSConfig[profile_name].config_hash
+        session_name = "piculet-session-#{Time.now.to_i}"
+        sts = AWS::STS.new(AWSConfig[profile_name].config_hash)
+        provider = AWS::Core::CredentialProviders::AssumeRoleProvider.new(sts: sts, role_arn: role_arn, role_session_name: session_name)
+      else
+        provider = AWS::Core::CredentialProviders::SharedCredentialFileProvider.new(credentials_opts)
+      end
       aws_opts[:credential_provider] = provider
     elsif (access_key and !secret_key) or (!access_key and secret_key) or mode.nil?
       puts opt.help

--- a/lib/piculet.rb
+++ b/lib/piculet.rb
@@ -10,6 +10,7 @@ require 'hashie'
 require 'ipaddr'
 
 require 'aws-sdk-v1'
+require 'aws_config'
 
 require 'piculet/ext/ec2-owner-id-ext'
 require 'piculet/ext/security-group'

--- a/piculet.gemspec
+++ b/piculet.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "term-ansicolor", ">= 1.2.2"
   spec.add_dependency "diffy"
   spec.add_dependency "hashie"
+  spec.add_dependency "aws_config", "0.1.0"
 
   #spec.files         = `git ls-files`.split($/)
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }

--- a/piculet.gemspec
+++ b/piculet.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "diffy"
   spec.add_dependency "hashie"
   spec.add_dependency "aws_config", "0.1.0"
+  spec.add_dependency "nokogiri", "~> 1.6.8"
 
   #spec.files         = `git ls-files`.split($/)
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }

--- a/piculet.gemspec
+++ b/piculet.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "diffy"
   spec.add_dependency "hashie"
   spec.add_dependency "aws_config", "0.1.0"
-  spec.add_dependency "nokogiri", "~> 1.6.8"
 
   #spec.files         = `git ls-files`.split($/)
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }


### PR DESCRIPTION
When "IAM User `codenize`" have "IAM Role `assumed`", you can run `piculet` with "IAM Role `assumed`" .

## Credentials

.aws/credentials
```
[codenize]
aws_access_key_id = XXXXXXXXXXXXXXXXXXX
aws_secret_access_key = XXXXXXXXXxxxxxXXXXXXXXxxxxXXXXXX
```

.aws/config
```
[profile assumed]
role_arn = arn:aws:iam::1234567890:role/read-only
source_profile = codenize
```

## Command

```sh
$ piculet -e -o Groupfile -r ap-northeast-1 --profile assumed # and output with assumed
```
