### PR TITLE
Freeze nokogiri version to `~> 1.6.8`

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -2,3 +2,4 @@
 --require spec_helper
 --require rspec/instafail
 --format RSpec::Instafail
+--format progress

--- a/piculet.gemspec
+++ b/piculet.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "term-ansicolor", ">= 1.2.2"
   spec.add_dependency "diffy"
   spec.add_dependency "hashie"
+  spec.add_dependency "nokogiri", "~> 1.6.8"
 
   #spec.files         = `git ls-files`.split($/)
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }


### PR DESCRIPTION
Because nokogiri 1.7.1 requires Ruby version >= 2.1.0.