### PR TITLE
Adding support for additional AWS CLI Environment Variables

### DIFF
--- a/bin/piculet
+++ b/bin/piculet
@@ -52,6 +52,10 @@ ARGV.options do |opt|
     opt.on(''  , '--debug')                         {    options[:debug]              = true        }
     opt.parse!
 
+    credentials_path ||= ENV['AWS_CONFIG_FILE']
+    profile_name     ||= ENV['AWS_DEFAULT_PROFILE']
+    region           ||= ENV['AWS_DEFAULT_REGION']
+
     aws_opts = {}
     if access_key and secret_key
       aws_opts = {


### PR DESCRIPTION
`AWS_CONFIG_FILE` - equivalent to `--credentials-path`
`AWS_DEFAULT_PROFILE` - equivalent to `--profile`
`AWS_DEFAULT_REGION` - equivalent to `--region`

The above will be used if present, and the user has not explicitly
provided a value via cli arguments when invoking piculet.

Addresses #30 