### PR TITLE
Feature/support aws profile

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -2,3 +2,4 @@
 --require spec_helper
 --require rspec/instafail
 --format RSpec::Instafail
+--format progress

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: ruby
 rvm:
 - 2.0.0
 script:
-- bundle install
 - bundle exec rake
 env:
   global:

--- a/bin/piculet
+++ b/bin/piculet
@@ -60,9 +60,25 @@ ARGV.options do |opt|
       }
     elsif profile_name or credentials_path
       credentials_opts = {}
-      credentials_opts[:profile_name] = profile_name if profile_name
-      credentials_opts[:path] = credentials_path if credentials_path
-      provider = AWS::Core::CredentialProviders::SharedCredentialFileProvider.new(credentials_opts)
+      if credentials_path
+        credentials_opts[:path] = credentials_path
+        AWSConfig.credentials_file = credentials_path
+      end
+      if profile_name
+        credentials_opts[:profile_name] = profile_name
+        role_arn = AWSConfig[profile_name][:role_arn]
+      end
+      if role_arn
+        session_name = "piculet-session-#{Time.now.to_i}"
+        sts = AWS::STS.new(AWSConfig[profile_name].config_hash)
+        provider = AWS::Core::CredentialProviders::AssumeRoleProvider.new(
+          sts: sts,
+          role_arn: role_arn,
+          role_session_name: session_name
+        )
+      else
+        provider = AWS::Core::CredentialProviders::SharedCredentialFileProvider.new(credentials_opts)
+      end
       aws_opts[:credential_provider] = provider
     elsif (access_key and !secret_key) or (!access_key and secret_key) or mode.nil?
       puts opt.help

--- a/bin/piculet
+++ b/bin/piculet
@@ -53,7 +53,7 @@ ARGV.options do |opt|
     opt.parse!
 
     credentials_path ||= ENV['AWS_CONFIG_FILE']
-    profile_name     ||= ENV['AWS_DEFAULT_PROFILE']
+    profile_name     ||= ENV['AWS_DEFAULT_PROFILE'] || ENV['AWS_PROFILE']
     region           ||= ENV['AWS_DEFAULT_REGION']
 
     aws_opts = {}

--- a/bin/piculet
+++ b/bin/piculet
@@ -52,6 +52,10 @@ ARGV.options do |opt|
     opt.on(''  , '--debug')                         {    options[:debug]              = true        }
     opt.parse!
 
+    credentials_path ||= ENV['AWS_CONFIG_FILE']
+    profile_name     ||= ENV['AWS_DEFAULT_PROFILE']
+    region           ||= ENV['AWS_DEFAULT_REGION']
+
     aws_opts = {}
     if access_key and secret_key
       aws_opts = {

--- a/lib/piculet.rb
+++ b/lib/piculet.rb
@@ -10,6 +10,7 @@ require 'hashie'
 require 'ipaddr'
 
 require 'aws-sdk-v1'
+require 'aws_config'
 
 require 'piculet/ext/ec2-owner-id-ext'
 require 'piculet/ext/security-group'

--- a/lib/piculet/version.rb
+++ b/lib/piculet/version.rb
@@ -1,3 +1,3 @@
 module Piculet
-  VERSION = "0.2.9"
+  VERSION = "0.3.0.beta"
 end

--- a/lib/piculet/wrapper/security-group.rb
+++ b/lib/piculet/wrapper/security-group.rb
@@ -7,7 +7,7 @@ module Piculet
 
         def_delegators(
           :@security_group,
-          :vpc_id, :name, :vpc?)
+          :vpc_id, :name)
 
         def initialize(security_group, options)
           @security_group = security_group
@@ -40,6 +40,10 @@ module Piculet
               @options.updated = true
             end
           end
+        end
+
+        def vpc?
+          !!@security_group
         end
 
         def tags

--- a/piculet.gemspec
+++ b/piculet.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "term-ansicolor", ">= 1.2.2"
   spec.add_dependency "diffy"
   spec.add_dependency "hashie"
+  spec.add_dependency "nokogiri", "~> 1.6.8"
 
   #spec.files         = `git ls-files`.split($/)
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }

--- a/piculet.gemspec
+++ b/piculet.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "diffy"
   spec.add_dependency "hashie"
   spec.add_dependency "nokogiri", "~> 1.6.8"
+  spec.add_dependency "aws_config", "0.1.0"
 
   #spec.files         = `git ls-files`.split($/)
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }


### PR DESCRIPTION
As mentioned in the issue of aws-cli, currently it is more common to support `AWS_PROFILE` as the profile's environmental value.  Refer https://github.com/aws/aws-cli/issues/1281 .  More, in this issue, you can see that for compatibility, aws-cli implements them in the precedence of `--profile > AWS_DEFAULT_PROFILE > AWS_PROFILE`.

So, I thought it'd be nice for piculet to support this the same way as `aws-cli`.  Any opinion?