### PR TITLE
fix escaping of exclude arg

### DIFF
--- a/bin/piculet
+++ b/bin/piculet
@@ -95,7 +95,7 @@ ARGV.options do |opt|
     # Remap groups to exclude to regular expressions (if they're surrounded by '/')
     if options[:exclude_sgs]
       options[:exclude_sgs].map! do |name|
-        name =~ /\A\/(.*)\/\z/ ? Regexp.new($1) : Regexp.new("\A#{Regexp.escape(name)}\z")
+        name =~ /\A\/(.*)\/\z/ ? Regexp.new($1) : Regexp.new("\\A#{Regexp.escape(name)}\\z")
       end
     end
 


### PR DESCRIPTION
we need to more escape backslashes

```
irb(main):001:0> name = 'foobar'
=> "foobar"
irb(main):002:0> re = Regexp.new("\A#{Regexp.escape(name)}\z")
=> /Afoobarz/
irb(main):003:0> re.match('foobar')
=> nil
irb(main):004:0> re.match('Afoobarz')
=> #<MatchData "Afoobarz">
```

```
irb(main):005:0> re = Regexp.new("\\A#{Regexp.escape(name)}\\z")
=> /\Afoobar\z/
irb(main):006:0> re.match('foobar')
=> #<MatchData "foobar">
```
