### PR TITLE
Update nokogiri version for security

### DIFF
--- a/piculet.gemspec
+++ b/piculet.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "term-ansicolor", ">= 1.2.2"
   spec.add_dependency "diffy"
   spec.add_dependency "hashie"
-  spec.add_dependency "nokogiri", "~> 1.6.8"
+  spec.add_dependency "nokogiri", "~> 1.8.2"
   spec.add_dependency "aws_config", "0.1.0"
 
   #spec.files         = `git ls-files`.split($/)


### PR DESCRIPTION
from https://github.com/codenize-tools/piculet/issues/37

Update nokogiri version for security vulnerabilities.

![](https://user-images.githubusercontent.com/311408/38791527-4131d73e-4183-11e8-9a42-3a85613cdd55.png)

